### PR TITLE
IOTSTOOL-1891 Notification retries for failed requests

### DIFF
--- a/MbedCloudSDK/MbedCloudSDK.csproj
+++ b/MbedCloudSDK/MbedCloudSDK.csproj
@@ -53,6 +53,7 @@
     <PackageReference Include="RestSharp" Version="106.2.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="All" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.4.1" />
+    <PackageReference Include="Polly" Version="6.1.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Added notification mechanism based on Polly
https://github.com/App-vNext/Polly
Now retries for HTTP Status 500 without stopping the notifications up to ~2 mins